### PR TITLE
feat: Parameterize backend API URL for production

### DIFF
--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -12,8 +12,9 @@ const Dashboard = () => {
   const [operations, setOperations] = useState([]);
 
   useEffect(() => {
-    // In a real app, this URL would be in an environment variable
-    fetch('http://localhost:3001/api/operations')
+    const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+
+    fetch(`${apiUrl}/api/operations`)
       .then(response => response.json())
       .then(data => setOperations(data))
       .catch(error => console.error('Error fetching operations:', error));


### PR DESCRIPTION
This commit prepares the frontend application for deployment on platforms like Vercel by abstracting the backend API URL into an environment variable.

The `Dashboard.js` component no longer uses a hardcoded `http://localhost:3001` URL. It now fetches data from the URL specified in the `REACT_APP_API_URL` environment variable.

A fallback to `http://localhost:3001` is included to ensure that the local development environment continues to work seamlessly without any additional configuration. This makes the application flexible for both development and production environments.